### PR TITLE
[OTD-8088] Pin dependency versions to prevent deadlocks in Olive3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,14 @@ from distutils.core import setup
 
 setup(
     name='Google MRF',
-    version='0.1',
+    version='0.2',
     description='Client for Google MRF and media measurement schema service.',
     author='Josh Fyne',
     author_email='josh.fyne@essencedigital.com',
     url='https://github.com/essence-tech/google-mrf-interface',
     packages=['googlemrf'],
-    install_requires=['grpcio', 'protobuf'],
+    install_requires=[
+        'grpcio==1.4.0',
+        'protobuf==3.4.0'
+    ],
     )


### PR DESCRIPTION
Hi Josh. Unfortunately unpinned dependency versions in this repo are causing huge problems with Olive3 Celery workers. We want to pin them to fix the problem in Olive3. Could you please review and accept this PR? 

Pin dependency versions:
- protobuf (to the latest available in pypi)
- grpcio to 1.4.0 which is the latest known working version on Olive3. 

P.S. I don't see any test command in the makefile, could you please suggest if there is any other way to test my changes other than installing it into Olive3 docker image and running the task?

@vladekm adding you as a reviewer as well because I cannot add anyone from the Olive3 team (seems like they do not have permissions to see the repo).

Related Olive3 PR: https://github.com/essence-tech/olive3/pull/1063

